### PR TITLE
Added support for mysql databases

### DIFF
--- a/config-bot.json.example.remote
+++ b/config-bot.json.example.remote
@@ -3,5 +3,5 @@
 	"POGOM_PATH": "/PATH/TO/POGOM",
 	"DEFAULT_LANG": "en",
 	"SEND_MAP_ONLY": true,
-	"POGOM_SQL": "false"
+	"POGOM_SQL": "mysql://username:password@hostname:port/databaseName"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 python-telegram-bot==5.0.0
+PyMySQL==0.7.9
+


### PR DESCRIPTION
Hey,

Yes, I realised that there would be problems as soon as I pressed the pull request. I'll explain what I did, so you can have a check.
- Added PyMySQL==0.7.9 to requirements.txt as it does not ship normally
- Imported PyMySQL as re (to parse the mysql string)
- Added a line to the config-bot.json which is 'false' for a local db and a string in the format mysql://user:pass@host:port/database
- Changed the connect to database section to read the preference.
- If mysql, parse the config file and then connect using pymysql. This has the advantage that you can use the cur = con.parser(); and not have to change code.

I have tested this with my local db and remote db and it has worked, but please check as I might have been silly.

I hope this helps. :-)
